### PR TITLE
Add build.yaml so supervisor populates BUILD_FROM

### DIFF
--- a/anylist/build.yaml
+++ b/anylist/build.yaml
@@ -1,0 +1,5 @@
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.15
+  amd64: ghcr.io/home-assistant/amd64-base:3.15
+  armv7: ghcr.io/home-assistant/armv7-base:3.15
+  i386: ghcr.io/home-assistant/i386-base:3.15


### PR DESCRIPTION
## Summary

Adds `anylist/build.yaml` with per-architecture base image mappings so the Supervisor can populate `BUILD_FROM` when building the addon.

Fixes #16.

## Why

Without `build.yaml`, `ARG BUILD_FROM` is empty and newer BuildKit versions reject the empty base name outright:

```
ERROR: failed to build: failed to solve: base name ($BUILD_FROM) should not be blank
Dockerfile:2
   1 |     ARG BUILD_FROM
   2 | >>> FROM $BUILD_FROM
```

## Test plan

- [x] Installed on Home Assistant OS (aarch64) — build succeeds and addon starts
- [x] HACS integration connects and add/remove/check operations work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)